### PR TITLE
Remove comments referencing an old plone_tableless skin layer.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,8 @@ Changelog
 1.2.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove comments referencing an old plone_tableless skin layer.
+  [danjacka]
 
 
 1.2.3 (2012-08-14)

--- a/plonetheme/classic/skins/classic_styles/columns.css.dtml
+++ b/plonetheme/classic/skins/classic_styles/columns.css.dtml
@@ -1,8 +1,5 @@
 /*
 ** Table-based column layout for all browsers.
-**
-** There's a table-less column layout alternative in the plone_tableless
-** skin layer, if you prefer layouts without tables.
 */
 
 /* <dtml-with base_properties> */

--- a/plonetheme/classic/skins/classic_styles/controlpanel.css.dtml
+++ b/plonetheme/classic/skins/classic_styles/controlpanel.css.dtml
@@ -1,8 +1,5 @@
 /*
 ** Table-based column layout for all browsers.
-**
-** There's a table-less column layout alternative in the plone_tableless
-** skin layer, if you prefer layouts without tables.
 */
 
 /* <dtml-with base_properties> */


### PR DESCRIPTION
I found these mentions of plone_tableless confusing. Best I can tell, they refer to the skin layer in http://pypi.python.org/pypi/Products.PloneTableless. Looking at https://dev.plone.org/ticket/5967, the tableless skin layer has not been actively supported since before Plone 3.0.
